### PR TITLE
[REFACTOR] : 언마운트된 컴포넌트의 불필요한 state 변경 제거

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,12 +1,12 @@
 import { FaSpinner, FaTrash } from 'react-icons/fa';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { deleteTodo } from '../api/todo';
 
 type TodoItemProps = {
-	id: string,
-	title: string,
-	setTodos: React.Dispatch<React.SetStateAction<Todo[]>>,
+	id: string;
+	title: string;
+	setTodos: React.Dispatch<React.SetStateAction<Todo[]>>;
 };
 
 const TodoItem = ({ id, title, setTodos }: TodoItemProps) => {
@@ -21,10 +21,12 @@ const TodoItem = ({ id, title, setTodos }: TodoItemProps) => {
 		} catch (error) {
 			console.error(error);
 			alert('Something went wrong.');
-		} finally {
-			setIsLoading(false);
 		}
 	}, [id, setTodos]);
+
+	useEffect(() => {
+		return () => setIsLoading(false);
+	}, []);
 
 	return (
 		<li className="item">


### PR DESCRIPTION
- 언마운트된 컴포넌트에서 불필요한 state 변경이 일어나 메모리 누수의 위험성이 존재하고 있어 이를 제거하고자 했습니다.
    -   이를 위해 useEffect의 cleanup function을 이용해 컴포넌트가 언마운트 되기전 해당 동작을 진행하도록 변경했습니다.
    -   컴포넌트가 언마운트가 되지 않는 경우 즉 api 통신이 정상적으로 일어나지 않은 경우에만 해당 동작이 필요해 catch문 안으로 옮기는 해결책도 존재했지만 useEffect를 활용하는 것이 코드의 가독성이 더 높다 생각되어 useEffect를 해결책으로 사용했습니다.